### PR TITLE
Fix residual auth findings from #366/#367

### DIFF
--- a/koalixcrm/accounting/serializers/booking_serializer.py
+++ b/koalixcrm/accounting/serializers/booking_serializer.py
@@ -54,13 +54,7 @@ class BookingJSONSerializer(serializers.ModelSerializer):
         booking.booking_date = validated_data['booking_date']
         booking.booking_reference = validated_data['booking_reference']
 
-        # Deserialize from staff
-        request = self.context.get('request')
-        koalixcrm_user = request.META.get('HTTP_KOALIXCRM_USER')
-        if koalixcrm_user:
-            user = User.objects.get(username=koalixcrm_user)
-        else:
-            user = request.user
+        user = self.context['request'].user
         booking.staff = user
         booking.last_modified_by = user
 
@@ -97,14 +91,7 @@ class BookingJSONSerializer(serializers.ModelSerializer):
         booking.booking_date = validated_data['booking_date']
         booking.booking_reference = validated_data['booking_reference']
 
-        # Deserialize from staff
-        request = self.context.get('request')
-        koalixcrm_user = request.META.get('HTTP_KOALIXCRM_USER')
-        if koalixcrm_user:
-            user = User.objects.get(username=koalixcrm_user)
-        else:
-            user = request.user
-        booking.staff = user
+        booking.staff = self.context['request'].user
 
         # Deserialize from account
         from_account = validated_data.pop('from_account')

--- a/koalixcrm/contacts/serializers/customer_serializer.py
+++ b/koalixcrm/contacts/serializers/customer_serializer.py
@@ -1,4 +1,3 @@
-from django.contrib.auth.models import User
 from rest_framework import serializers
 
 from koalixcrm.contacts.models.customer import Customer
@@ -35,14 +34,7 @@ class CustomerJSONSerializer(ContactJSONSerializer):
             else:
                 customer.default_customer_billing_cycle = None
 
-        # Deserialize from staff
-        request = self.context.get('request')
-        koalixcrm_user = request.META.get('HTTP_KOALIXCRM_USER')
-        if koalixcrm_user:
-            user = User.objects.get(username=koalixcrm_user)
-        else:
-            user = request.user
-        customer.last_modified_by = user
+        customer.last_modified_by = self.context['request'].user
 
         customer.save()
 
@@ -61,14 +53,7 @@ class CustomerJSONSerializer(ContactJSONSerializer):
         customer.name = validated_data.get('name', customer.name)
         customer.is_lead = validated_data.get('is_lead', customer.is_lead)
 
-        # Deserialize from staff
-        request = self.context.get('request')
-        koalixcrm_user = request.META.get('HTTP_KOALIXCRM_USER')
-        if koalixcrm_user:
-            user = User.objects.get(username=koalixcrm_user)
-        else:
-            user = request.user
-        customer.last_modified_by = user
+        customer.last_modified_by = self.context['request'].user
 
         # Deserialize from customer group
         # Clear all from existing customer and add the deserialized items again.

--- a/koalixcrm/core/views/set_timezone.py
+++ b/koalixcrm/core/views/set_timezone.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
 import zoneinfo
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 
 
+@login_required
 def set_timezone(request):
     if request.method == 'POST':
         request.session['django_timezone'] = request.POST['timezone']

--- a/koalixcrm/reporting/views/reporting_period_missing.py
+++ b/koalixcrm/reporting/views/reporting_period_missing.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.template.context_processors import csrf
@@ -18,6 +19,7 @@ class ReportingPeriodMissingForm(forms.Form):
                                    choices=NEXT_STEPS)
 
 
+@login_required
 def reporting_period_missing(request):
     try:
         if request.POST.get('post'):

--- a/koalixcrm/reporting/views/user_is_not_human_resource.py
+++ b/koalixcrm/reporting/views/user_is_not_human_resource.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect, Http404
 from django.shortcuts import render
 from django.template.context_processors import csrf
@@ -18,6 +19,7 @@ class ReportingPeriodMissingForm(forms.Form):
                                    choices=NEXT_STEPS)
 
 
+@login_required
 def user_is_not_human_resource(request):
     try:
         if request.POST.get('post'):

--- a/koalixcrm/reporting/views/work_entry_form.py
+++ b/koalixcrm/reporting/views/work_entry_form.py
@@ -87,10 +87,19 @@ class WorkEntry(forms.Form):
         return cleaned_data
 
     def update_work(self, request):
+        from django.core.exceptions import PermissionDenied
         from koalixcrm.reporting.models.work import Work
         if self.has_changed():
+            current_human_resource = HumanResource.objects.get(user=UserExtension.get_user_extension(request.user))
             if self.cleaned_data['work_id']:
-                work = Work.objects.get(id=self.cleaned_data['work_id'])
+                # Only allow access to Work entries owned by the current user's HumanResource.
+                # Without this filter, any authenticated user could edit/delete other users' work
+                # by tampering with the hidden work_id form field.
+                try:
+                    work = Work.objects.get(id=self.cleaned_data['work_id'],
+                                            human_resource=current_human_resource)
+                except Work.DoesNotExist:
+                    raise PermissionDenied("You are not allowed to modify this work entry.")
             else:
                 if not self.cleaned_data['DELETE']:
                     work = Work()
@@ -102,7 +111,7 @@ class WorkEntry(forms.Form):
                 work.task = self.cleaned_data['task']
                 work.reporting_period = ReportingPeriod.get_reporting_period(project=self.cleaned_data['task'].project,
                                                                              search_date=self.cleaned_data['datetime_start'].date())
-                work.human_resource = HumanResource.objects.get(user=UserExtension.get_user_extension(request.user))
+                work.human_resource = current_human_resource
                 work.date = self.cleaned_data['datetime_start'].date()
                 if bool(self.cleaned_data['datetime_start']) & bool(self.cleaned_data['datetime_stop']):
                     work.start_time = self.cleaned_data['datetime_start']


### PR DESCRIPTION
- Remove HTTP_KOALIXCRM_USER impersonation header path in customer and booking serializers; always attribute writes to request.user.
- Add ownership check in WorkEntry.update_work so Work entries can only be edited/deleted via the form by the user that owns them (closes the IDOR via hidden work_id field).
- Add @login_required to set_timezone, reporting_period_missing, and user_is_not_human_resource — the three remaining custom views that lacked it after the v2.0.0 restructure.

Refs #366, #367